### PR TITLE
Update transfer_test.go

### DIFF
--- a/db/sqlc/transfer_test.go
+++ b/db/sqlc/transfer_test.go
@@ -65,7 +65,7 @@ func TestListTransfer(t *testing.T) {
 		FromAccountID: account1.ID,
 		ToAccountID:   account1.ID,
 		Limit:         5,
-		Offset:        5,
+		Offset:        0,
 	}
 
 	transfers, err := testQueries.ListTransfers(context.Background(), arg)


### PR DESCRIPTION
Hello,

Please review this and let me know if this is not correct.

I tried on my end and test was failing saying len =[0].
So I changed offset and it passed.

This test was failing because offset was set to 5 so, it gets list of zero transfers and  Required len is 5 in order to pass the test..

Thanks